### PR TITLE
add support to pass bigquery objects into bigquery functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     name='python-io',
     description='Python tools to read/write from/to external services',
-    version='0.1.0',
+    version='0.1.1',
     packages=find_packages(include=['iolib*']),
     install_requires=[
         'google-cloud-bigquery>=2.0.0,<4.0.0',

--- a/tests/iolib/test_bigquery.py
+++ b/tests/iolib/test_bigquery.py
@@ -1,6 +1,11 @@
 from unittest import mock
 
-from google.cloud.bigquery import Table
+from google.cloud.bigquery import (
+    Dataset,
+    DatasetReference,
+    Table,
+    TableReference,
+)
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,71 +16,154 @@ from iolib import read_bigquery, write_bigquery
 
 @mock.patch('iolib.bigquery.Client')
 def test_bigquery_table_manager_creates_client(m_client):
-    manager = BigqueryTableManager(dataset=mock.ANY, table=mock.ANY)
+    manager = BigqueryTableManager(dataset='<dataset>', table='<table>')
     assert m_client.return_value == manager.client
 
 
 @mock.patch('iolib.bigquery.Client')
 def test_bigquery_table_manager_creates_client_from_service_account(m_client):
-    manager = BigqueryTableManager(dataset=mock.ANY,
-                                   table=mock.ANY,
+    manager = BigqueryTableManager(dataset='<dataset>',
+                                   table='<table>',
                                    service_account_json='<service_account_json>')
     m_client.from_service_account_json.assert_called_once_with('<service_account_json>')
     assert m_client.from_service_account_json.return_value == manager.client
 
 
 @mock.patch('iolib.bigquery.Client')
-def test_bigquery_table_manager_defines_dataset_and_table_as_passed(m_client):
-    manager = BigqueryTableManager(dataset='<dataset>', table='<table>')
-    assert '<dataset>' == manager.dataset
-    assert '<table>' == manager.table
-    assert 'project' not in vars(manager.client)  # BQ client sets project automatically from service account.
+def test_bigquery_table_manager_defines_dataset_and_table_by_parsing_table(m_client):
+    m_client.return_value.project = '<project>'
+    manager = BigqueryTableManager(table='<dataset>.<table>')
+    assert m_client.return_value.get_dataset.return_value == manager.dataset
+    assert m_client.return_value.get_table.return_value == manager.table
+    assert '<project>' == manager.client.project
 
 
 @mock.patch('iolib.bigquery.Client')
-def test_bigquery_table_manager_defines_dataset_and_table_by_parsing_table_id(m_client):
-    manager = BigqueryTableManager(table_id='<dataset>.<table>')
-    assert '<dataset>' == manager.dataset
-    assert '<table>' == manager.table
-    assert 'project' not in vars(manager.client)  # BQ client sets project automatically from service account.
-
-
-@mock.patch('iolib.bigquery.Client')
-def test_bigquery_table_manager_defines_project_dataset_and_table_by_parsing_table_id(m_client):
-    manager = BigqueryTableManager(table_id='<project>.<dataset>.<table>')
-    assert '<dataset>' == manager.dataset
-    assert '<table>' == manager.table
+def test_bigquery_table_manager_defines_project_dataset_and_table_by_parsing_table(m_client):
+    manager = BigqueryTableManager(table='<project>.<dataset>.<table>')
+    assert m_client.return_value.get_dataset.return_value == manager.dataset
+    assert m_client.return_value.get_table.return_value == manager.table
     assert '<project>' == manager.client.project
 
 
 @mock.patch('iolib.bigquery.Client')
 def test_bigquery_table_manager_defines_project_as_passed(m_client):
-    manager = BigqueryTableManager(dataset=mock.ANY,
-                                   table=mock.ANY,
+    manager = BigqueryTableManager(dataset='<dataset>',
+                                   table='<table>',
                                    project='<project>')
     assert '<project>' == manager.client.project
 
 
 @mock.patch('iolib.bigquery.Client')
-def test_bigquery_table_manager_errors_if_invalid_table_id(m_client):
+def test_bigquery_table_manager_defines_dataset_from_str(m_client):
+    manager = BigqueryTableManager(dataset='<dataset>', table='<table>')
+    dataset_ref = m_client.return_value.dataset.return_value
+    dataset = m_client.return_value.get_dataset.return_value
+    assert dataset == manager.dataset
+    m_client.return_value.dataset.assert_called_once_with('<dataset>')
+    m_client.return_value.get_dataset.assert_called_once_with(dataset_ref)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_defines_dataset_from_dataset_ref(m_client):
+    dataset_ref = DatasetReference('<project>', '<dataset>')
+    manager = BigqueryTableManager(dataset=dataset_ref, table='<table>')
+    dataset = m_client.return_value.get_dataset.return_value
+    assert dataset == manager.dataset
+    m_client.return_value.get_dataset.assert_called_once_with(dataset_ref)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_defines_dataset_from_dataset(m_client):
+    dataset_ref = DatasetReference('<project>', '<dataset>')
+    dataset = Dataset(dataset_ref)
+    manager = BigqueryTableManager(dataset=dataset, table='<table>')
+    assert dataset == manager.dataset
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_defines_table_from_str(m_client):
+    manager = BigqueryTableManager(dataset='<dataset>', table='<table>')
+    table_ref = m_client.return_value.table.return_value
+    table = m_client.return_value.get_table.return_value
+    assert table == manager.table
+    m_client.return_value.table.assert_called_once_with('<table>')
+    m_client.return_value.get_table.assert_called_once_with(table_ref)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_defines_table_and_dataset_from_table_ref(m_client):
+    table_ref = TableReference(DatasetReference('<project>', '<dataset>'),
+                               '<table>')
+    table = m_client.return_value.get_table.return_value
+    dataset = m_client.return_value.get_dataset.return_value
+    table.dataset_id = '<dataset>'
+    manager = BigqueryTableManager(table=table_ref)
+    assert table == manager.table
+    assert dataset == manager.dataset
+    m_client.return_value.get_table.assert_called_once_with(table_ref)
+    dataset_ref = m_client.return_value.dataset.return_value
+    m_client.return_value.dataset.assert_called_once_with('<dataset>')
+    m_client.return_value.get_dataset(dataset_ref)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_defines_table_and_dataset_from_table(m_client):
+    table_ref = TableReference(DatasetReference('<project>', '<dataset>'),
+                               '<table>')
+    table = Table(table_ref)
+    dataset = m_client.return_value.get_dataset.return_value
+    manager = BigqueryTableManager(table=table)
+    assert table == manager.table
+    assert dataset == manager.dataset
+    dataset_ref = m_client.return_value.dataset.return_value
+    m_client.return_value.dataset.assert_called_once_with('<dataset>')
+    m_client.return_value.get_dataset(dataset_ref)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_errors_if_invalid_table_from_parsed_table_id(m_client):
     with pytest.raises(AssertionError) as error:
         BigqueryTableManager('foo.bar.egg.bacon')
     assert 'Invalid table_id `foo.bar.egg.bacon`' == str(error.value)
 
 
 @mock.patch('iolib.bigquery.Client')
-def test_bigquery_table_manager_errors_if_no_dataset_and_table(m_client):
+def test_bigquery_table_manager_errors_if_invalid_dataset(m_client):
     with pytest.raises(AssertionError) as error:
-        BigqueryTableManager()
-    assert 'dataset and table are required, either passed directly or as part of table_id' == str(error.value)
+        BigqueryTableManager(dataset=1, table='<table>')
+    assert 'Invalid dataset `1`' == str(error.value)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_errors_if_missing_dataset(m_client):
+    with pytest.raises(AssertionError) as error:
+        BigqueryTableManager(table='<table>')
+    assert 'Missing dataset' == str(error.value)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_errors_if_invalid_table(m_client):
+    with pytest.raises(AssertionError) as error:
+        BigqueryTableManager(table=1, dataset='<dataset>')
+    assert 'Invalid table `1`' == str(error.value)
+
+
+@mock.patch('iolib.bigquery.Client')
+def test_bigquery_table_manager_errors_if_missing_table(m_client):
+    with pytest.raises(AssertionError) as error:
+        BigqueryTableManager(table=None, dataset='<dataset>')
+    assert 'Missing table' == str(error.value)
 
 
 @mock.patch.object(BigqueryTableManager, '__init__', return_value=None)
 @mock.patch.object(BigqueryTableManager, 'client', new_callable=mock.PropertyMock())
 def test_bigquery_table_manager_reads_with_query(m_client, _):
     manager = BigqueryTableManager()
-    manager.dataset = '<dataset>'
-    manager.table = '<table>'
+    manager.dataset = mock.PropertyMock()
+    manager.dataset.dataset_id = '<dataset>'
+    manager.table = mock.PropertyMock()
+    manager.table.table_id = '<table>'
     manager.client.project = '<project>'
     actual = manager.read(query='SELECT foo FROM `{table_id}`')
     m_client.query.assert_called_once_with(
@@ -87,8 +175,10 @@ def test_bigquery_table_manager_reads_with_query(m_client, _):
 @mock.patch.object(BigqueryTableManager, 'client', new_callable=mock.PropertyMock())
 def test_bigquery_table_manager_reads_without_query(m_client, _):
     manager = BigqueryTableManager()
-    manager.dataset = '<dataset>'
-    manager.table = '<table>'
+    manager.dataset = mock.PropertyMock()
+    manager.dataset.dataset_id = '<dataset>'
+    manager.table = mock.PropertyMock()
+    manager.table.table_id = '<table>'
     m_client.project = '<project>'
     actual = manager.read()
     m_client.query.assert_called_once_with('SELECT * FROM `<project>.<dataset>.<table>`')
@@ -99,6 +189,11 @@ def test_bigquery_table_manager_reads_without_query(m_client, _):
 @mock.patch.object(BigqueryTableManager, 'client', new_callable=mock.PropertyMock())
 def test_bigquery_table_manager_replaces_none_by_nan_when_reading(m_client, _):
     manager = BigqueryTableManager()
+    manager.dataset = mock.PropertyMock()
+    manager.dataset.dataset_id = '<dataset>'
+    manager.table = mock.PropertyMock()
+    manager.table.table_id = '<table>'
+    m_client.project = '<project>'
     m_client.query.return_value.to_dataframe.return_value = pd.DataFrame([{'x': None}])
     actual = manager.read(query='SELECT foo FROM bar')
     expected = pd.DataFrame([{'x': np.nan}])
@@ -109,19 +204,11 @@ def test_bigquery_table_manager_replaces_none_by_nan_when_reading(m_client, _):
 @mock.patch.object(BigqueryTableManager, 'client', new_callable=mock.PropertyMock())
 def test_bigquery_table_manager_writes_from_list(m_client, _):
     manager = BigqueryTableManager()
-    manager.dataset = '<dataset>'
-    manager.table = '<table>'
+    manager.table = mock.PropertyMock()
     data = [(1,), (2,), (3,)]
     m_client.insert_rows.return_value = None
     manager.write(data)
-    # Test setup.
-    m_client.dataset.assert_called_once_with('<dataset>')
-    m_client.dataset.return_value.table.assert_called_once_with('<table>')
-    table_ref = m_client.dataset.return_value.table.return_value
-    m_client.get_table.assert_called_once_with(table_ref)
-    table = m_client.get_table.return_value
-    # Test write.
-    m_client.insert_rows.assert_called_once_with(table, data)
+    m_client.insert_rows.assert_called_once_with(manager.table, data)
 
 
 @mock.patch.object(BigqueryTableManager, '__init__', return_value=None)
@@ -134,17 +221,14 @@ def test_bigquery_table_manager_writes_from_dataframe(m_client, _):
             self.name = name
 
     manager = BigqueryTableManager()
-    manager.dataset = '<dataset>'
-    manager.table = '<table>'
+    manager.table = mock.PropertyMock()
+    manager.table.schema = [DummyColumn('a')]
     data = pd.DataFrame([{'a': 'x', 'b': 1}, {'a': np.nan, 'b': 2}])
     m_client.insert_rows.return_value = None
-    table = m_client.get_table.return_value
-    table.schema = [DummyColumn('a')]
     manager.write(data)
-    # Test write.
     m_client.insert_rows_from_dataframe.assert_called_once()
     args, kwargs = m_client.insert_rows_from_dataframe.call_args
-    assert table == args[0]
+    assert manager.table == args[0]
     pd.testing.assert_frame_equal(pd.DataFrame([{'a': 'x'}, {'a': np.nan}]), args[1])
     assert {'chunk_size': 1000} == kwargs
 
@@ -153,18 +237,14 @@ def test_bigquery_table_manager_writes_from_dataframe(m_client, _):
 @mock.patch.object(BigqueryTableManager, 'client', new_callable=mock.PropertyMock())
 def test_bigquery_table_manager_replaces_table_when_writing(m_client, _):
     manager = BigqueryTableManager()
-    manager.dataset = '<dataset>'
-    manager.table = '<table>'
+    table = mock.PropertyMock()
+    manager.table = table
     data = [(1,), (2,), (3,)]
     m_client.insert_rows.return_value = None
     manager.write(data, replace=True)
-    # Test setup.
-    table_ref = m_client.dataset.return_value.table.return_value
-    table = m_client.get_table.return_value
     new_table = m_client.create_table.return_value
-    m_client.delete_table.assert_called_once_with(table_ref)
-    m_client.create_table.assert_called_once_with(Table(table_ref, schema=table.schema))
-    # Test write.
+    m_client.delete_table.assert_called_once_with(table.reference)
+    m_client.create_table.assert_called_once_with(Table(manager.table.reference, schema=manager.table.schema))
     m_client.insert_rows.assert_called_once_with(new_table, data)
 
 
@@ -172,15 +252,12 @@ def test_bigquery_table_manager_replaces_table_when_writing(m_client, _):
 @mock.patch.object(BigqueryTableManager, 'client', new_callable=mock.PropertyMock())
 def test_bigquery_table_manager_writes_in_batches(m_client, _):
     manager = BigqueryTableManager()
-    manager.dataset = '<dataset>'
-    manager.table = '<table>'
+    manager.table = mock.PropertyMock()
     data = [(1,), (2,), (3,), (4,), (5,)]
     m_client.insert_rows.return_value = None
     manager.write(data, chunk_size=3)
-    # Test write.
-    table = m_client.get_table.return_value
-    calls = [mock.call(table, [(1,), (2,), (3,)]),
-             mock.call(table, [(4,), (5,)])]
+    calls = [mock.call(manager.table, [(1,), (2,), (3,)]),
+             mock.call(manager.table, [(4,), (5,)])]
     assert calls == m_client.insert_rows.call_args_list
 
 
@@ -188,8 +265,6 @@ def test_bigquery_table_manager_writes_in_batches(m_client, _):
 @mock.patch.object(BigqueryTableManager, 'client', new_callable=mock.PropertyMock())
 def test_bigquery_table_manager_errors_if_insert_rows_errors_when_writing(m_client, _):
     manager = BigqueryTableManager()
-    manager.dataset = '<dataset>'
-    manager.table = '<table>'
     m_client.insert_rows.return_value = 'An error from Bigquery'
     with pytest.raises(Exception) as error:
         manager.write([(1,)])
@@ -198,13 +273,13 @@ def test_bigquery_table_manager_errors_if_insert_rows_errors_when_writing(m_clie
 
 @mock.patch('iolib.bigquery.BigqueryTableManager')
 def test_read_bigquery_uses_manager(m_manager):
-    actual = read_bigquery(table_id='<table_id>', query='<query>')
-    m_manager.assert_called_once_with(table_id='<table_id>')
+    actual = read_bigquery(table='<table>', query='<query>')
+    m_manager.assert_called_once_with(table='<table>')
     m_manager.return_value.read.assert_called_once_with(query='<query>')
 
 
 @mock.patch('iolib.bigquery.BigqueryTableManager')
 def test_write_bigquery_uses_manager(m_manager):
-    actual = write_bigquery(table_id='<table_id>', data='<data>')
-    m_manager.assert_called_once_with(table_id='<table_id>')
+    actual = write_bigquery(table='<table>', data='<data>')
+    m_manager.assert_called_once_with(table='<table>')
     m_manager.return_value.write.assert_called_once_with(data='<data>')


### PR DESCRIPTION
Allow to pass `table` as `google.cloud.bigquery.TableReference` and `google.cloud.bigquery.Table`, and `dataset` as `google.cloud.bigquery.DatasetReference` and `google.cloud.bigquery.Dataset` in bigquery functions.
Also, remove `table_id` argument. Use `table`.

Example:

```python
>>> from google.cloud import Dataset, DatasetReference, Table, TableReference
>>> from iolib import read_bigquery, write_bigquery
>>> read_bigquery(project='project', dataset='dataset', table='table')
[...]
>>> write_bigquery(table='project.dataset.table')
[...]
>>> dataset_ref = DatasetReference('project', 'dataset')
>>> table_ref = TableReference(dataset_ref, 'table')
>>> read_bigquery(table=table_ref)
[...]
>>> write_bigquery(table=Table(table_ref))
[...]
```

TODO: create release 0.1.1 once merged (and think how to automate new releases).