### PR TITLE
format class docstring as code in documentation

### DIFF
--- a/scripts/generate_documentation.py
+++ b/scripts/generate_documentation.py
@@ -75,7 +75,7 @@ for dirpath, _, filenames in os.walk(iolib_root):
             content = ''
             content += f'## {class_name}\n\n'
             if (docstring := inspect.getdoc(cls)):
-                content += f'{docstring}\n'
+                content += f'```{docstring}\n```\n\n'
             for obj_name, obj in inspect.getmembers(cls):
                 if obj_name.startswith('_') or \
                         not (inspect.ismethod(obj) or inspect.isfunction(obj)):


### PR DESCRIPTION
Docstring for classes were not wrapped by "```".
![Screenshot from 2022-07-20 16-04-36](https://user-images.githubusercontent.com/2114106/180002437-11fb0b7b-b963-444b-a00a-098c5fc3663d.png)

