### PR TITLE
change error on bigquery write fail

### DIFF
--- a/iolib/bigquery.py
+++ b/iolib/bigquery.py
@@ -173,7 +173,7 @@ class BigqueryTableManager:
         if_exists : str = 'fail'
             Behavior when the destination table exists. Value can be one of:
             'fail'
-                If table exists, raise google.api_core.exceptions.NotFound.
+                If table exists, raise ValueError.
             'replace'
                 If table exists, delete it, recreate it, and insert data.
             'append'
@@ -191,7 +191,10 @@ class BigqueryTableManager:
 
         if if_exists == 'fail':
             if self.table.created:
-                self._raise_table_not_found()
+                raise ValueError(
+                    'Table already exists. Use `if_exists="replace"` or '
+                    '`if_exists="append"` if you want to modify the table.`'
+                )
             self.table = self.client.create_table(self.table)
 
         elif if_exists == 'replace':

--- a/tests/iolib/test_bigquery.py
+++ b/tests/iolib/test_bigquery.py
@@ -284,14 +284,15 @@ def test_bigquery_table_manager_errors_if_invalid_if_exists_when_writing(_):
 
 
 @mock.patch.object(BigqueryTableManager, '__init__', return_value=None)
-@mock.patch.object(BigqueryTableManager, '_raise_table_not_found', side_effect=raise_not_found)
-def test_bigquery_table_manager_errors_if_table_exists_when_writing(m_raise_table_not_found, _):
+def test_bigquery_table_manager_errors_if_table_exists_when_writing(_):
     manager = BigqueryTableManager()
     manager.table = mock.PropertyMock()
     manager.table.created = True
-    with pytest.raises(NotFound):
+    with pytest.raises(ValueError) as error:
         manager.write(mock.ANY, if_exists='fail')
-    m_raise_table_not_found.assert_called_once()
+    message = 'Table already exists. Use `if_exists="replace"` or '\
+              '`if_exists="append"` if you want to modify the table.`'
+    assert message == str(error.value)
 
 
 @mock.patch.object(BigqueryTableManager, '__init__', return_value=None)


### PR DESCRIPTION
Raise `ValueError` instead of `NotFound` if trying to write into an existing table with `if_exists='fail'`, replicating the pandas' behaviour 