### PR TITLE
add to_snakecase function

### DIFF
--- a/iolib/utils.py
+++ b/iolib/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from googleapiclient.discovery import build
 from google.oauth2.service_account import Credentials
@@ -10,3 +11,12 @@ def build_google_api(name, version, scopes, service_account_json=None):
     credentials = Credentials.from_service_account_file(service_account_json,
                                                         scopes=scopes)
     return build(name, version, credentials=credentials)
+
+
+def to_snakecase(value):
+    # Add underscore between lower and uppercased letter.
+    value = re.sub(r'(?<=[a-w])([A-W])', r'_\1', value)
+    # Replace dash or space by underscore.
+    value = re.sub(r'[ -]', '_', value)
+    value = value.lower()
+    return value

--- a/tests/iolib/test_utils.py
+++ b/tests/iolib/test_utils.py
@@ -1,6 +1,8 @@
 from unittest import mock
 
-from iolib.utils import build_google_api
+import pytest
+
+from iolib.utils import build_google_api, to_snakecase
 
 
 @mock.patch('iolib.utils.Credentials')
@@ -37,3 +39,15 @@ def test_build_google_api_with_credentials_from_env(m_os, m_build, m_credentials
         service_account_json,
         scopes=scopes)
     m_build.assert_called_once_with(name, version, credentials=credentials)
+
+
+@pytest.mark.parametrize(('value', 'expected'), (
+    ('to_csv', 'to_csv'),
+    ('user name', 'user_name'),
+    ('Email Address', 'email_address'),
+    ('phoneNumber', 'phone_number'),
+    ('toHTML', 'to_html'),
+))
+def test_to_snakecase(value, expected):
+    actual = to_snakecase(value)
+    assert expected == actual


### PR DESCRIPTION
Example:

```python
>>> to_snakecase('emailAddress')
'email_address'
```

This util function will be used in following pull requests.