### PR TITLE
Normalize keys

### DIFF
--- a/iolib/drive.py
+++ b/iolib/drive.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from .utils import build_google_api, to_snakecase
+from .utils import build_google_api, normalize_key
 
 
 API_NAME = 'drive'
@@ -55,7 +55,7 @@ def list_drive(name=None,
                       includeItemsFromAllDrives=True,
                       supportsAllDrives=True)
     result = api.files().list(**kwargs).execute()['files']
-    return pd.DataFrame(result).rename(columns=to_snakecase)
+    return pd.DataFrame(result).rename(columns=normalize_key)
 
 
 def format_search_query(name=None, folder_id=None, mime_type=None):

--- a/iolib/utils.py
+++ b/iolib/utils.py
@@ -5,6 +5,17 @@ from googleapiclient.discovery import build
 from google.oauth2.service_account import Credentials
 
 
+# Common keys/fields returned from third-party map to normalized keys to be
+# used accross the whole library for consistency.
+NORMALIZED_KEYS_MAP = {
+    'pass': 'password',
+    'passwd': 'password',
+    'username': 'user',
+    'user_name': 'user',
+    'email_address': 'email',
+}
+
+
 def build_google_api(name, version, scopes, service_account_json=None):
     if not service_account_json:
         service_account_json = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
@@ -20,3 +31,14 @@ def to_snakecase(value):
     value = re.sub(r'[ -]', '_', value)
     value = value.lower()
     return value
+
+
+def normalize_key(key):
+    """
+    Normalized value from a key. The key will be snakecased and replaced if
+    found in our common keys dictionary. This function is used for consistency
+    in the function returns. For example, all the following keys will be
+    returned as "user": "USER", "username", "User_Name".
+    """
+    key = to_snakecase(key)
+    return NORMALIZED_KEYS_MAP.get(key, key)

--- a/tests/iolib/test_utils.py
+++ b/tests/iolib/test_utils.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from iolib.utils import build_google_api, to_snakecase
+from iolib.utils import build_google_api, to_snakecase, normalize_key
 
 
 @mock.patch('iolib.utils.Credentials')
@@ -51,3 +51,14 @@ def test_build_google_api_with_credentials_from_env(m_os, m_build, m_credentials
 def test_to_snakecase(value, expected):
     actual = to_snakecase(value)
     assert expected == actual
+
+
+@pytest.mark.parametrize(('value', 'expected'), (
+    ('name', 'name'),
+    ('user_name', 'user'),
+))
+def test_normalize_key(value, expected):
+    with mock.patch('iolib.utils.to_snakecase', side_effect=lambda x: x) as m_to_snakecase:
+        actual = normalize_key(value)
+    assert expected == actual
+    m_to_snakecase.assert_called_once_with(value)


### PR DESCRIPTION
Normalized value from a key. The key will be snakecased and replaced if found in our common keys dictionary. This function is used for consistency in the function returns. For example, all the following keys will be returned as "user": "USER", "username", "User_Name".