### PR TITLE
Improve wiki

### DIFF
--- a/iolib/bigquery.py
+++ b/iolib/bigquery.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 
-def parse_schema(schema):
+def parse_schema(schema):  # wiki: ignore
     """
     Create a list of google.cloud.bigquery.SchemaField from a list of dicts.
     """

--- a/iolib/drive.py
+++ b/iolib/drive.py
@@ -59,7 +59,7 @@ def list_drive(name=None,
     return pd.DataFrame(result).rename(columns=normalize_key)
 
 
-def format_search_query(name=None, folder_id=None, mime_type=None):
+def format_search_query(name=None, folder_id=None, mime_type=None):  # wiki: ignore
     """
     Format query to use in Google Drive `files.list`.
 

--- a/iolib/sheets.py
+++ b/iolib/sheets.py
@@ -114,7 +114,7 @@ def write_sheets(data,
     return {'id': result['spreadsheetId']}
 
 
-def format_cell_value(value):
+def format_cell_value(value):  # wiki: ignore
     """
     Format the value of the spreadsheet cell. This value will be serialized as
     JSON in the Google libraries.

--- a/iolib/storage.py
+++ b/iolib/storage.py
@@ -66,7 +66,7 @@ def read_storage(bucket_name,
     return result
 
 
-def read_blob(blob, encoding='utf-8', **kwargs):
+def read_blob(blob, encoding='utf-8', **kwargs):  # wiki: ignore
     _, ext = os.path.splitext(blob.name)
     if ext != '.csv':
         raise Exception('Only CSV currently supported')

--- a/scripts/generate_documentation.py
+++ b/scripts/generate_documentation.py
@@ -92,6 +92,9 @@ for dirpath, _, filenames in os.walk(iolib_root):
 
         # Render functions documentation.
         for obj_name, obj in inspect.getmembers(module, inspect.isfunction):
+            # Exclude imported functions.
+            if obj.__module__ != module_name:
+                continue
             if exclude_object(obj):
                 continue
             content += f'## {obj_name}\n\n'

--- a/scripts/generate_documentation.py
+++ b/scripts/generate_documentation.py
@@ -39,6 +39,10 @@ def generate_item_doc(executable, class_name=None):
     return content
 
 
+def exclude_object(obj):
+    return '# wiki: ignore' in inspect.getsource(obj)
+
+
 def save_file(name, content):
     with open(os.path.join(docs_root, f'{name}.md'), 'w') as infile:
         infile.write(content)
@@ -73,6 +77,8 @@ for dirpath, _, filenames in os.walk(iolib_root):
             # Exclude imported classes.
             if cls.__module__ != module_name:
                 continue
+            if exclude_object(cls):
+                continue
             content = ''
             content += f'## {class_name}\n\n'
             if (docstring := inspect.getdoc(cls)):
@@ -86,6 +92,8 @@ for dirpath, _, filenames in os.walk(iolib_root):
 
         # Render functions documentation.
         for obj_name, obj in inspect.getmembers(module, inspect.isfunction):
+            if exclude_object(obj):
+                continue
             content += f'## {obj_name}\n\n'
             content += generate_item_doc(obj)
 


### PR DESCRIPTION
- Manually exclude classes or functions from autogenerated wiki by adding the comment `# wiki: ignore`
- Exclude imported functions